### PR TITLE
fix eval error while parsing response with \u2028  \u2029

### DIFF
--- a/libs/adstream/data/Service.js
+++ b/libs/adstream/data/Service.js
@@ -279,7 +279,7 @@ dojo.declare( 'adstream.data.Service', null, {
 				if( ioargs.xhr.status < 400 )	err = new Error( "Unexpected content type returned: " + content_type );
 			} else if( response ) {
 				var json;
-				try { json = dojo.fromJson( response ); } catch( e ) {
+				try { json = JSON.parse( response.replace(/\u2028|\u2029/g, "\\$&") ); } catch( e ) {
 					err = new Error( "Malformed response from the server: bad JSON syntax" );
 				}
 				if( json )	try { result = this._sync( json, arg_url ); } catch( e ) { err = e; }


### PR DESCRIPTION
Due to this reason http://timelessrepo.com/json-isnt-a-javascript-subset
eval falls while trying to parse string with 
\u2028 - Line separator
\u2029 - Paragraph separator.
Another variant is replace dojo.fromJson by JSON.parse. It avoids such error. But some old browsers doesn't support JSON. Is it be beteer to replace it by JSON.parse?
